### PR TITLE
Jad/eng 117 not all inscriptions load for some wallets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nosft-core",
-    "version": "2.3.54",
+    "version": "2.3.61",
     "engines": {
         "node": ">=18.0.0"
     },


### PR DESCRIPTION
So it turns out that mempool will only return 50 unconfirmed txs

The above address, according to https://mempool.deezy.io/api/address/bc1p47rmwnzr5lmk5dz5a5pf4vfm64qgvk7v6g4ast0kp3vqp35y5lfqlw7whg, has 228 unconfirmed utxos. Whether we use Mempool or Blockstream, from my research, there is no way to circumvent the 50 tx limit via API. 

Mempool behavior: Usually we call https://mempool.deezy.io/api/address/bc1p47rmwnzr5lmk5dz5a5pf4vfm64qgvk7v6g4ast0kp3vqp35y5lfqlw7whg/txs and then https://mempool.deezy.io/api/address/bc1p47rmwnzr5lmk5dz5a5pf4vfm64qgvk7v6g4ast0kp3vqp35y5lfqlw7whg/txs/chain/[txid]

But the problem with the above is Mempool does not allow pagination by unconfirmed txid. And the first API call returns 50 unconfirmed txs. So we need a way to get the latest confirmed txid to paginate through all confirmed txs

The proper fix is to first make the call to /txs to only get unconfirmed txs. Then continue to paginate via txs/chain, then txs/chain/[txid]